### PR TITLE
2015-10-21 AC: Modifies the gitignore file in order to exclude Zend Studio's .buildpath file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .settings/
 .project
+.buildpath
 deployment.properties
 deployment.xml
-deployment*
 


### PR DESCRIPTION
Forgot to exclude Zend Studio's .buildpath file from the repo.
